### PR TITLE
Amend example

### DIFF
--- a/R/base_plot.R
+++ b/R/base_plot.R
@@ -327,7 +327,7 @@
 #'
 #' # overlay (fussy to work with)
 #' #ppom <- ggplot_build(pp0 + pp1[2] + pp2[[2]] + scale_color_discrete(guide="none"))
-#' ppom <- ggplot_build(pp0ee + pp1ee[2] + pp2ee[[2]] + scale_color_discrete(guide="none"))
+#' ppom <- ggplot_build(pp0ee + pp1ee[2] + pp2ee[2] + scale_color_discrete(guide="none"))
 #' ppom$data[[1]]$colour <- ppom$data[[2]]$colour <- "gray40" # emmval = 0 -> dark gray
 #' ppom$data[[3]]$colour <- ppom$data[[4]]$colour <- "gray80" # emmval = 1 -> light gray
 #' ppom$data[[5]]$colour <- ppom$data[[6]]$colour <- "black" # emmval = 2 -> black

--- a/man/plot.qgcompemmfit.Rd
+++ b/man/plot.qgcompemmfit.Rd
@@ -100,7 +100,7 @@ pp1 + theme_linedraw() # can use with other ggplot functions
 
 # overlay (fussy to work with)
 #ppom <- ggplot_build(pp0 + pp1[2] + pp2[[2]] + scale_color_discrete(guide="none"))
-ppom <- ggplot_build(pp0ee + pp1ee[2] + pp2ee[[2]] + scale_color_discrete(guide="none"))
+ppom <- ggplot_build(pp0ee + pp1ee[2] + pp2ee[2] + scale_color_discrete(guide="none"))
 ppom$data[[1]]$colour <- ppom$data[[2]]$colour <- "gray40" # emmval = 0 -> dark gray
 ppom$data[[3]]$colour <- ppom$data[[4]]$colour <- "gray80" # emmval = 1 -> light gray
 ppom$data[[5]]$colour <- ppom$data[[6]]$colour <- "black" # emmval = 2 -> black


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was an example where a plot object was subsetted in a way that will no longer work.
This PR will make the example compatible with the new version of ggplot2, and to the best of my knowledge, also the old version.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun